### PR TITLE
3mts: fix support for borderless

### DIFF
--- a/OpenParrot/src/Utility/TouchSerial/MT6.cpp
+++ b/OpenParrot/src/Utility/TouchSerial/MT6.cpp
@@ -170,6 +170,7 @@ DWORD mt6SerialTouchThread(HANDLE port)
 			if (memcmp(fileBuf, CMD_RESET, 3) == 0)
 			{
 				puts("CMD_RESET");
+				mt6SetDisplayParams(gameWindow);
 				bHasBooted = FALSE;
 				packetRecognised = TRUE;
 				mt6WritePort(port, OK_RESPONSE, 3);


### PR DESCRIPTION
Changes:
Reset display parameters on touchscreen reset, because "Borderless Gaming" takes a few seconds to change the window size. Without that change, the emu would grab the original window size BEFORE borderless mode has resized it.